### PR TITLE
Add one-to-one proxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,8 @@ node client.js --in=example.png --content-type=image/png --remote-file-name=`dat
 
 ## Method 3: Any-to-any proxy
 
-(coming soon)
+Example (put this in front of your remoteStorage server to get a Cozy API to it for free):
+
+````bash
+node translator --server-type-front=cozy --server-type-back=remotestorage --host-back=storage.5apps.com --port-back=443 --base-path-back=/dswg/test/ --port-front=8124 --credentials-back=3a0d6830acea73605bde4e919b107886 --credentials-front=asdf
+````

--- a/client.js
+++ b/client.js
@@ -10,7 +10,7 @@ function run() {
   if (argv) {
     var stream = fs.createReadStream(argv['in']);
     translator.send(argv.host, argv.port, argv.basePath, argv.credentials,
-        argv.remoteFileName, argv.contentType, stream, argv.serverType, function (err, data) {
+        argv.remoteFileName, argv.contentType, stream, argv.serverType, false, function (err, data) {
       console.log(err, data);
     });
   }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
           <option value="remotestorage">remotestorage</option>
           <option value="cozy">cozy</option>
           <option value="owncloud">owncloud</option>
+          <option value="cozy-to-rs">cozy-to-rs</option>
         </select>
       </div>
  
@@ -21,6 +22,9 @@
  
         <label for="server-port">Server port:</label>
         <input type="text" id="server-port" name="server-port">
+
+        <input type="checkbox" id="disable-tls" name="disable-tls">
+        <label for="disable-tls">Disable TLS</label>
       </div>
  
       <div>
@@ -47,6 +51,7 @@
      if (document.getElementById('server-type').value === 'remotestorage') {
        document.getElementById('server-host').value = 'storage.5apps.com';
        document.getElementById('server-port').value = '443';
+       document.getElementById('disable-tls').checked = false;
        document.getElementById('base-path').value = '/dswg/test/';
        document.getElementById('remote-filename').value = new Date().getTime().toString();
        document.getElementById('credentials').value = '3a0d6830acea73605bde4e919b107886';
@@ -59,9 +64,17 @@
      } else if (document.getElementById('server-type').value === 'owncloud') {
        document.getElementById('server-host').value = 'owncloud.michielbdejong.com';
        document.getElementById('server-port').value = '443';
+       document.getElementById('disable-tls').checked = false;
        document.getElementById('base-path').value = '/remote.php/webdav/';
        document.getElementById('remote-filename').value = new Date().getTime().toString();
        document.getElementById('credentials').value = 'b2h5dUg4RWlwaWUxY2hvbzVzaGFpc2hlZXphaVNvaDJhdG91ZjNhYTphaENlMW9hYm9oMmFlcGhvbzVrYWhnaGFlbjlsZWFRdWFpMHpvb2tp';
+     } else if (document.getElementById('server-type').value === 'cozy-to-rs') {
+       document.getElementById('server-host').value = 'localhost';
+       document.getElementById('server-port').value = '8124';
+       document.getElementById('disable-tls').checked = true;
+       document.getElementById('base-path').value = '/';
+       document.getElementById('remote-filename').value = new Date().getTime().toString();
+       document.getElementById('credentials').value = 'asdf';
      } else {
        document.getElementById('server-host').value = '';
        document.getElementById('server-port').value = '';

--- a/lib/translator.js
+++ b/lib/translator.js
@@ -1,15 +1,8 @@
-var https = require('https'),
+var http = require('http'),
+    https = require('https'),
     fs = require('fs');
 
-function parse(req, formatIn, callback) {
-  var filename = (formatIn === 'cozy' ? req.url.substr(-4) : req.url);
-  callback(null, {
-    authorizationHeader: req.headers.Authorization,
-    filename: filename
-  });
-}
-
-function send(backendHost, backendPort, backendPath, credentials, filename, contentType, stream, formatOut, callback) {
+function send(backendHost, backendPort, backendPath, credentials, filename, contentType, stream, formatOut, disableTls, callback) {
   var options = {
     hostname: backendHost,
     port: backendPort,
@@ -23,8 +16,9 @@ function send(backendHost, backendPort, backendPath, credentials, filename, cont
       Authorization: (formatOut === 'remotestorage' ? 'Bearer ' : 'Basic ') + credentials
     }
   };
+  
 console.log(options);
-  var req = https.request(options, function(res) {
+  var req = (disableTls ? http : https).request(options, function(res) {
     var ret = {
       statusCode: res.statusCode,
       responseHeaders: res.headers,
@@ -44,33 +38,6 @@ console.log(options);
     });
   });
   stream.pipe(req);
-
-  req.on('error', function(e) {
-    console.error(e);
-  });
-  req.on('end', function() {
-    callback(null, {
-      status: 201,
-      headers: {},
-      body: ''
-    });
-  });
 }
 
 module.exports.send = send;
-module.exports.parse = parse;
-module.exports.server = function(cert, formatIn, formatOut, backendPort) {
-  https.createServer(cert, function(req, res) {
-    parse(req, formatIn, function(err, metadata, stream) {
-      send(backendHost, backendPort, metadata.authorizationHeader, metadata.filename, stream, formatOut, function (err, result) {
-        if (err) {
-          res.writeHead(500);
-          res.end(err.toString());
-        } else {
-          res.writeHead(result.code, result.headers);
-          res.end(result.body);
-        }
-      });
-    });
-  });
-};

--- a/server.js
+++ b/server.js
@@ -18,7 +18,8 @@ function run() {
         //todo: use form.onPart to stream this directly instead of via disk:
         stream = fs.createReadStream(files['file-contents'].path);
         translator.send(fields['server-host'], fields['server-port'], fields['base-path'], fields.credentials,
-            fields['remote-filename'], files['file-contents'].type, stream, fields['server-type'], function (err, data) {
+            fields['remote-filename'], files['file-contents'].type, stream, fields['server-type'], fields['disable-tls'],
+            function (err, data) {
           res.writeHead(200, {'content-type': 'text/plain'});
           res.write('received upload:\n\n');
           res.end(util.inspect({fields: fields, files: files, err: err, data: data}));

--- a/translator.js
+++ b/translator.js
@@ -1,0 +1,54 @@
+var translator = require('./lib/translator'),
+    http = require('http'),
+    sslRootCAs = require('ssl-root-cas/latest'),
+    checkArgs = require('./lib/args').checkArgs;
+
+function checkCredentials(authHeader, serverType, correct) {
+  var prefixLength;
+  if (serverType === 'remotestorage') {
+    prefixLength = 'Bearer '.length;
+  } else {
+    prefixLength = 'Basic '.length;
+  }
+  return (authHeader.substring(prefixLength) === correct);
+}
+
+function determineFilename(urlPath, serverType) {
+  var withoutSlash = urlPath.substring('/');
+  if (serverType === 'cozy') {
+    return withoutSlash.substring(0, withoutSlash.length - '/raw'.length);
+  } else {
+    return withoutSlash;
+  }
+}
+
+function run() {
+  var argv = checkArgs(['server-type-front', 'server-type-back', 'host-back', 'port-back', 'base-path-back', 'port-front',
+                 'credentials-back', 'credentials-front']);
+  sslRootCAs.inject().addFile('./ca.pem');
+  if (argv) {
+    http.createServer(function(req, res) {
+console.log(req.headers);
+      if (checkCredentials(req.headers.authorization, argv['server-type-front'], argv['credentials-front'])) {
+        translator.send(argv['host-back'], argv['port-back'], argv['base-path-back'], argv['credentials-back'],
+            determineFilename(req.url, argv['server-type-front']), req.headers['content-type'], req,
+            argv['server-type-back'], false, function (err, data) {
+          if (err) {
+            res.writeHead(500);
+            res.end(err.toString());
+          } else {
+            res.writeHead(data.statusCode, data.responseHeaders);
+            res.end(data.responseBody);
+          }
+        });
+      } else {
+        res.writeHead(401);
+        res.end('please match the translator\'s --credentials-front argument in your Authorization header');
+      }
+    }).listen(argv['port-front']);
+    console.log('There is now a ' + argv['server-type-front'] + ' server on http://localhost:' + argv['port-front']);
+  }
+}
+
+//...
+run();


### PR DESCRIPTION
If you own a remoteStorage server, then you can put this one-to-one translator next to it, and publish your Cozy-compatible interface. In the example I used http, so that you can run it on localhost without cert-signing difficulties
