### PR TITLE
Simplify Cozy curl example

### DIFF
--- a/doc/curl-examples.md
+++ b/doc/curl-examples.md
@@ -41,10 +41,7 @@ curl -vX GET http://localhost:5984/database/doc/attachment
 
 Here is an actual working example for this cozy : https://paulsharing2.cozycloud.cc
 ````bash
-#Document creation : 
-curl -vX POST https://Upsc0D0Xruhe9bj5qB3U4HcZidDEkAgd:dC4KvlfBwqriMJ3aCAjG6qLddPkPgr5z@paulsharing2.cozycloud.cc/cozy/ -H 'Content-Type: application/json'  -d '{"doctest": "mydoctest"}'
-#Put the attachment : 
-curl -vX PUT https://Upsc0D0Xruhe9bj5qB3U4HcZidDEkAgd:dC4KvlfBwqriMJ3aCAjG6qLddPkPgr5z@paulsharing2.cozycloud.cc/cozy/<doc_id>/attachment?rev=<rev> --data-binary @<image_path> -H "Content-Type: image/jpg"
+curl -vX PUT https://Upsc0D0Xruhe9bj5qB3U4HcZidDEkAgd:dC4KvlfBwqriMJ3aCAjG6qLddPkPgr5z@paulsharing2.cozycloud.cc/cozy/`date +%s`/raw --data-binary @<image_path> -H "Content-Type: image/jpg"
 ````
 
 # To send this file to a Swell server:


### PR DESCRIPTION
- You can choose your own `doc_id`
- You can directly send the attachment, the document will be created automatically
- Use `data +%s` ad the `doc_id` to avoid filename clashes

@Gara64 please review
