### PR TITLE
Add self-signed certificate support

### DIFF
--- a/lib/translator.js
+++ b/lib/translator.js
@@ -17,6 +17,7 @@ function send(backendHost, backendPort, backendPath, credentials, filename, cont
     path: backendPath
         + filename
         + (formatOut === 'cozy' ? '/raw' : ''),
+    rejectUnauthorized: false,
     headers: {
       'If-None-Match': '*',
       'Content-Type': contentType,


### PR DESCRIPTION
Without rejectUnauthorized: false in the request options, we receive a [Error: DEPTH_ZERO_SELF_SIGNED_CERT] if the remote server has a self-signed certificate
